### PR TITLE
Make action checkout not shallow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -115,6 +115,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set env
         run: echo "RELEASE_VERSION=`git describe --tags`" >> $GITHUB_ENV


### PR DESCRIPTION
The default shallow checkout doesn't fetch tags, and those are needed for the `!version` command to return a useful result.