### PR TITLE
Don't react to own messages

### DIFF
--- a/botto/tld_botto.py
+++ b/botto/tld_botto.py
@@ -204,6 +204,10 @@ class TLDBotto(discord.Client):
             if channel_name in self.config["channels"]["exclude"]:
                 return
 
+        if message.author.id == self.user.id:
+            log.info("Ignoring message from self")
+            return
+
         await self.process_suggestion(message)
 
     def clean_trigger_message(self, trigger, message) -> str:


### PR DESCRIPTION
Sometimes TLDBotto apologise that it can't set a reminder and then warns itself for apologising....