### PR TITLE
Fixed missing colon

### DIFF
--- a/botto/config.py
+++ b/botto/config.py
@@ -150,7 +150,7 @@ def parse(config):
                 ),
                 "reactions": ["🐮", "🐄"],
             },
-            "honk"{
+            "honk":{
                 "trigger": "honk",
                 "reactions": ["🦆","📣","🎺","🎷","📢"],
             },


### PR DESCRIPTION
A colon in the triggers dictionary was missing. My bad.