### PR TITLE
Fix KeyError getting reaction role

### DIFF
--- a/botto/storage/beta_testers/beta_testers_storage.py
+++ b/botto/storage/beta_testers/beta_testers_storage.py
@@ -231,7 +231,7 @@ class BetaTestersStorage(Storage):
             if (
                 (server_config := self.reaction_roles_cache.get(str(server_id)))
                 and (msg_config := server_config.get(str(msg_id)))
-                and (config := msg_config[key])
+                and (config := msg_config.get(key))
             ):
                 return config
             else:


### PR DESCRIPTION
We can't assume that all keys are cached just because one is!