### PR TITLE
Provide default timezone to scheduler

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -2,6 +2,8 @@ import os
 import json
 import logging.config
 import asyncio
+
+import pytz
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from botto.clients import ClickUpClient, AppStoreConnectClient
@@ -34,7 +36,7 @@ except (IOError, OSError, ValueError) as err:
 
 log.info(f"Triggers: {config['triggers']}")
 
-scheduler = AsyncIOScheduler()
+scheduler = AsyncIOScheduler(timezone=pytz.UTC)
 
 storage = AirtableMealStorage(
     config["authentication"]["airtable_base"], config["authentication"]["airtable_key"]

--- a/botto/tld_botto.py
+++ b/botto/tld_botto.py
@@ -133,7 +133,6 @@ class TLDBotto(ClickupMixin, RemoteConfig, ReactionRoles, ExtendedClient):
                 name="Meal Reminder",
                 trigger="cron",
                 hour=reminder_hours,
-                timezone=pytz.UTC,
                 coalesce=True,
             )
         scheduler.add_job(


### PR DESCRIPTION
This should stop the:
> /usr/local/lib/python3.11/site-packages/tzlocal/unix.py:158: UserWarning: Can not find any timezone configuration, defaulting to UTC.
warnings.warn('Can not find any timezone configuration, defaulting to UTC.')

warning in the logs