### PR TITLE
Reduce logging level for discordpy

### DIFF
--- a/botto/food.py
+++ b/botto/food.py
@@ -113,7 +113,7 @@ default_config = {
     },
     "eye_roll_foods": {"triggers": ["🍽️"], "responses": ["🙄"]},
     "dangerous_foods": {
-        "triggers": ["💣", "🧨", "🗡️", "🔪", "🦠", "🧫"],
+        "triggers": ["💣", "🧨", "🗡️", "🔪", "🦠", "🧫", "💉"],
         "responses": ["🙅", "😨"],
     },
     "nausea": {"triggers": "🚬", "responses": ["🙅", "🤢"]},

--- a/botto/food.py
+++ b/botto/food.py
@@ -107,6 +107,10 @@ default_config = {
         "triggers": ["🍋", "🍆", "🍑", "🫑", "🥒", "🥦", "🧄", "🧅", "🍄", "🥚", "🧈"],
         "responses": ["😕"],
     },
+    "hard_to_open": {
+       "triggers": ["🥫"],
+       "responses": ["🔓", "🥺"],
+    },
     "eye_roll_foods": {"triggers": ["🍽️"], "responses": ["🙄"]},
     "dangerous_foods": {
         "triggers": ["💣", "🧨", "🗡️", "🔪", "🦠", "🧫"],


### PR DESCRIPTION
DiscordPy catches all errors being handled so setting to critical hides errors we might be generating