### PR TITLE
Fix Tildy reacting with 😵‍💫 to webhooks

### DIFF
--- a/botto/tld_botto.py
+++ b/botto/tld_botto.py
@@ -443,7 +443,7 @@ class TLDBotto(ClickupMixin, RemoteConfig, ReactionRoles, ExtendedClient):
                 webhook = await self.fetch_webhook(webhook_id)
                 if webhook.type != discord.WebhookType.incoming:
                     return
-            except discord.NotFound:
+            except discord.NotFound | discord.Forbidden:
                 pass
         if message.author.id == self.user.id:
             log.debug(f"Ignoring message {message.id} from self")

--- a/botto/tld_botto.py
+++ b/botto/tld_botto.py
@@ -443,7 +443,10 @@ class TLDBotto(ClickupMixin, RemoteConfig, ReactionRoles, ExtendedClient):
                 webhook = await self.fetch_webhook(webhook_id)
                 if webhook.type != discord.WebhookType.incoming:
                     return
-            except discord.NotFound | discord.Forbidden:
+            except discord.NotFound:
+                if message.author.id == self.user.id:
+                    return
+            except discord.Forbidden:
                 pass
         if message.author.id == self.user.id:
             log.debug(f"Ignoring message {message.id} from self")


### PR DESCRIPTION
If we don’t have permission to check them, we’ll just carry on as normal